### PR TITLE
Update “Donate” page link

### DIFF
--- a/_includes/shared/header.html
+++ b/_includes/shared/header.html
@@ -49,7 +49,7 @@
                         <li><a href="https://data.buffalony.gov/" target="_blank" style=color:#ffffff><i class="fa fa-database" style=color:#ffffff></i> OUR DATA</a></li>
             <!--li><a href="" target="_blank" style=color:#ffffff><i class="fa fa-rss" style=color:#ffffff></i> BLOG</a></li-->
             <li><a href="/contact" style=color:#ffffff><i class="fa fa-paper-plane" style=color:#ffffff></i> CONTACT</a></li>
-<li><a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20Buffalo" target="_blank" style=color:#ffffff><i class="fa fa-gift" style=color:#ffffff></i> DONATE</a></li>
+<li><a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20Buffalo&utm_source=CodeforBuffalo%20site" target="_blank" style=color:#ffffff><i class="fa fa-gift" style=color:#ffffff></i> DONATE</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>


### PR DESCRIPTION
We at Code for America created this new donate page [seven months
ago][1] because the old donate page required a high maintenance
burden and created an unnecessary duplication in our process.

This commit updates your website to link to the new Donate page.

[1]: https://groups.google.com/a/codeforamerica.org/g/brigadeleads/c/At0loymFW0I/m/OVC-W90yEAAJ